### PR TITLE
Use fmt::Display repr for ExitStatus when showing benchmark failures

### DIFF
--- a/src/bench_target.rs
+++ b/src/bench_target.rs
@@ -102,9 +102,9 @@ impl BenchTarget {
                         return Ok(());
                     } else {
                         return Err(anyhow!(
-                            "Non-Criterion.rs benchmark target {} exited with error code {:?}",
+                            "Non-Criterion.rs benchmark target {} exited with {}",
                             self.name,
-                            exit_status.code()
+                            exit_status
                         ));
                     }
                 }
@@ -185,9 +185,9 @@ impl BenchTarget {
                         return Ok(());
                     } else {
                         return Err(anyhow!(
-                            "Criterion.rs benchmark target {} exited with error code {:?}",
+                            "Criterion.rs benchmark target {} exited with {}",
                             self.name,
-                            exit_status.code()
+                            exit_status
                         ));
                     }
                 }


### PR DESCRIPTION
This way unix signals [don't get shown as just `None`](https://github.com/rust-lang/rust/blob/2616ab1c57e2d69f989307389b27ee996ed82575/library/std/src/sys/unix/process/process_unix.rs#L531-L545), and windows errors will get [printed out as hexadecimal](https://github.com/rust-lang/rust/blob/97717a561844eccbb6d6cc114adb94a8fa4e0172/library/std/src/sys/windows/process.rs#L416-L425)