### PR TITLE
Don't overwrite config option for output-format.

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -396,7 +396,6 @@ in the benchmark will not be optimized either. This may result in less-accurate 
                 .long("output-format")
                 .takes_value(true)
                 .possible_values(&["criterion", "quiet", "verbose", "bencher"])
-                .default_value("criterion")
                 .hide_default_value(true)
                 .hide_possible_values(true)
                 .help("Change the CLI output format. Possible values are criterion, quiet, verbose, bencher.")


### PR DESCRIPTION
The --output-format flag had a default value of "criterion" which overwrote the config value from 'Criterion.toml'. 

This patches changes the search order to:
 1. --output-format
 2. Criterion.toml
 3. OutputFormat::Criterion