### PR TITLE
Fix clippy warnings

### DIFF
--- a/src/analysis.rs
+++ b/src/analysis.rs
@@ -74,7 +74,7 @@ pub(crate) fn analysis<'a>(
     };
 
     MeasurementData {
-        data: Data::new(&*iters, &*values),
+        data: Data::new(iters, values),
         avg_times: labeled_sample,
         absolute_estimates: estimates,
         distributions,

--- a/src/bench_target.rs
+++ b/src/bench_target.rs
@@ -246,7 +246,7 @@ impl BenchTarget {
                     let avg_values: Vec<f64> = iters
                         .iter()
                         .zip(times.iter())
-                        .map(|(iter, time)| *time / (*iter as f64))
+                        .map(|(iter, time)| *time / *iter)
                         .collect();
 
                     if times.iter().any(|&f| f == 0.0) {

--- a/src/compile.rs
+++ b/src/compile.rs
@@ -82,7 +82,7 @@ pub fn compile(debug_build: bool, cargo_args: &[std::ffi::OsString]) -> Result<C
     let mut cargo = Command::new("cargo")
         .args(subcommand)
         .args(cargo_args)
-        .args(&["--no-run", "--message-format", "json-render-diagnostics"])
+        .args(["--no-run", "--message-format", "json-render-diagnostics"])
         .stdin(Stdio::null())
         .stderr(Stdio::inherit()) // Cargo writes its normal compile output to stderr
         .stdout(Stdio::piped()) // Capture the JSON messages on stdout

--- a/src/config.rs
+++ b/src/config.rs
@@ -189,7 +189,7 @@ pub struct FullConfig {
 /// Call `cargo criterion` and parse the output to get the path to the target directory.
 fn get_target_directory_from_metadata() -> Result<PathBuf> {
     let out = Command::new("cargo")
-        .args(&["metadata", "--format-version", "1"])
+        .args(["metadata", "--format-version", "1"])
         .output()?;
 
     #[derive(Deserialize)]

--- a/src/html/mod.rs
+++ b/src/html/mod.rs
@@ -487,7 +487,7 @@ impl Report for Html {
 
                 self.generate_summary(
                     &subgroup_id,
-                    &*samples_with_function,
+                    &samples_with_function,
                     context,
                     formatter,
                     false,
@@ -509,7 +509,7 @@ impl Report for Html {
 
                 self.generate_summary(
                     &subgroup_id,
-                    &*samples_with_value,
+                    &samples_with_value,
                     context,
                     formatter,
                     false,
@@ -521,7 +521,7 @@ impl Report for Html {
 
         self.generate_summary(
             &BenchmarkId::new(group_id.to_owned(), None, None, None),
-            &*(all_data),
+            &(all_data),
             context,
             formatter,
             true,

--- a/src/plot/mod.rs
+++ b/src/plot/mod.rs
@@ -431,8 +431,8 @@ impl<B: PlottingBackend> PlotGenerator<B> {
         let len = end - start;
 
         let distribution_curve = LineCurve {
-            xs: &*kde_xs,
-            ys: &*ys,
+            xs: &kde_xs,
+            ys: &ys,
         };
         let bootstrap_area = FilledCurve {
             xs: &kde_xs[start..end],
@@ -519,7 +519,7 @@ impl<B: PlottingBackend> PlotGenerator<B> {
             )
         };
 
-        let distribution_curve = LineCurve { xs: &*xs, ys: &*ys };
+        let distribution_curve = LineCurve { xs: &xs, ys: &ys };
         let confidence_interval = FilledCurve {
             xs: &xs[start..end],
             ys_1: &ys[start..end],
@@ -824,8 +824,8 @@ impl<B: PlottingBackend> PlotGenerator<B> {
         let [lost, lomt, himt, hist] = fences;
 
         let pdf = FilledCurve {
-            xs: &*xs,
-            ys_1: &*ys,
+            xs: &xs,
+            ys_1: &ys,
             ys_2: &vec![0.0; ys.len()],
         };
         let mean = VerticalLine { x: mean };
@@ -920,8 +920,8 @@ impl<B: PlottingBackend> PlotGenerator<B> {
             end: Point { x: mean, y: mean_y },
         };
         let pdf = FilledCurve {
-            xs: &*xs,
-            ys_1: &*ys,
+            xs: &xs,
+            ys_1: &ys,
             ys_2: &vec![0.0; ys.len()],
         };
 
@@ -970,8 +970,8 @@ impl<B: PlottingBackend> PlotGenerator<B> {
             },
         };
         let base_pdf = FilledCurve {
-            xs: &*base_xs,
-            ys_1: &*base_ys,
+            xs: &base_xs,
+            ys_1: &base_ys,
             ys_2: &vec![0.0; base_ys.len()],
         };
 
@@ -986,8 +986,8 @@ impl<B: PlottingBackend> PlotGenerator<B> {
             },
         };
         let current_pdf = FilledCurve {
-            xs: &*xs,
-            ys_1: &*ys,
+            xs: &xs,
+            ys_1: &ys,
             ys_2: &vec![0.0; base_ys.len()],
         };
 
@@ -1015,8 +1015,8 @@ impl<B: PlottingBackend> PlotGenerator<B> {
 
         let t = VerticalLine { x: t };
         let t_distribution = FilledCurve {
-            xs: &*xs,
-            ys_1: &*ys,
+            xs: &xs,
+            ys_1: &ys,
             ys_2: &vec![0.0; ys.len()],
         };
 
@@ -1272,7 +1272,7 @@ impl<B: PlottingBackend> Plotter for PlotGenerator<B> {
     }
 
     fn rel_distributions(&mut self, ctx: PlotContext<'_>, comparison: &ComparisonData) {
-        crate::plot::CHANGE_STATS.iter().for_each(|&statistic| {
+        CHANGE_STATS.iter().for_each(|&statistic| {
             self.rel_distribution(
                 ctx.id,
                 ctx.context,
@@ -1295,7 +1295,7 @@ impl<B: PlottingBackend> Plotter for PlotGenerator<B> {
         let max = all_curves
             .iter()
             .map(|(_, bench)| bench.latest_stats.estimates.typical().point_estimate)
-            .fold(::std::f64::NAN, f64::max);
+            .fold(f64::NAN, f64::max);
 
         let mut dummy = [1.0];
         let unit = formatter.scale_values(max, &mut dummy);
@@ -1306,7 +1306,7 @@ impl<B: PlottingBackend> Plotter for PlotGenerator<B> {
         for (id, bench) in all_curves {
             function_id_to_benchmarks
                 .entry(&id.function_id)
-                .or_insert(Vec::new())
+                .or_insert_with(Vec::new)
                 .push((*id, *bench))
         }
 
@@ -1332,7 +1332,7 @@ impl<B: PlottingBackend> Plotter for PlotGenerator<B> {
 
         let lines: Vec<_> = series_data
             .iter()
-            .map(|(name, xs, ys)| (*name, LineCurve { xs: &*xs, ys: &*ys }))
+            .map(|(name, xs, ys)| (*name, LineCurve { xs, ys }))
             .collect();
 
         self.backend.line_comparison(
@@ -1392,7 +1392,7 @@ impl<B: PlottingBackend> Plotter for PlotGenerator<B> {
 
         let lines = kdes
             .iter()
-            .map(|(name, xs, ys)| (*name, LineCurve { xs: &*xs, ys: &*ys }))
+            .map(|(name, xs, ys)| (*name, LineCurve { xs, ys }))
             .collect::<Vec<_>>();
 
         self.backend.violin(

--- a/src/plot/plotters_backend/distributions.rs
+++ b/src/plot/plotters_backend/distributions.rs
@@ -50,11 +50,11 @@ pub fn abs_distribution(
     chart
         .draw_series(LineSeries::new(
             distribution_curve.to_points(),
-            &colors.current_sample,
+            colors.current_sample,
         ))
         .unwrap()
         .label("Bootstrap distribution")
-        .legend(|(x, y)| PathElement::new(vec![(x, y), (x + 20, y)], &colors.current_sample));
+        .legend(|(x, y)| PathElement::new(vec![(x, y), (x + 20, y)], colors.current_sample));
 
     chart
         .draw_series(AreaSeries::new(
@@ -78,7 +78,7 @@ pub fn abs_distribution(
         )))
         .unwrap()
         .label("Point estimate")
-        .legend(|(x, y)| PathElement::new(vec![(x, y), (x + 20, y)], &colors.current_sample));
+        .legend(|(x, y)| PathElement::new(vec![(x, y), (x + 20, y)], colors.current_sample));
 
     chart
         .configure_series_labels()
@@ -130,11 +130,11 @@ pub fn rel_distribution(
     chart
         .draw_series(LineSeries::new(
             distribution_curve.to_points(),
-            &colors.current_sample,
+            colors.current_sample,
         ))
         .unwrap()
         .label("Bootstrap distribution")
-        .legend(|(x, y)| PathElement::new(vec![(x, y), (x + 20, y)], &colors.current_sample));
+        .legend(|(x, y)| PathElement::new(vec![(x, y), (x + 20, y)], colors.current_sample));
 
     chart
         .draw_series(AreaSeries::new(
@@ -158,7 +158,7 @@ pub fn rel_distribution(
         )))
         .unwrap()
         .label("Point estimate")
-        .legend(|(x, y)| PathElement::new(vec![(x, y), (x + 20, y)], &colors.current_sample));
+        .legend(|(x, y)| PathElement::new(vec![(x, y), (x + 20, y)], colors.current_sample));
 
     chart
         .draw_series(std::iter::once(Rectangle::new(

--- a/src/plot/plotters_backend/history.rs
+++ b/src/plot/plotters_backend/history.rs
@@ -49,11 +49,11 @@ pub fn history(
     chart
         .draw_series(LineSeries::new(
             point_estimate.to_points(),
-            &colors.current_sample,
+            colors.current_sample,
         ))
         .unwrap()
         .label("Point estimate")
-        .legend(|(x, y)| PathElement::new(vec![(x, y), (x + 20, y)], &colors.current_sample));
+        .legend(|(x, y)| PathElement::new(vec![(x, y), (x + 20, y)], colors.current_sample));
 
     let polygon_points: Vec<(f64, f64)> = confidence_interval
         .xs

--- a/src/plot/plotters_backend/iteration_times.rs
+++ b/src/plot/plotters_backend/iteration_times.rs
@@ -46,7 +46,7 @@ pub fn iteration_times(
         .configure_mesh()
         .y_desc(format!("Average Iteration Time ({})", unit))
         .x_label_formatter(&|x| pretty_print_float(*x, true))
-        .light_line_style(&TRANSPARENT)
+        .light_line_style(TRANSPARENT)
         .draw()
         .unwrap();
 

--- a/src/plot/plotters_backend/pdf.rs
+++ b/src/plot/plotters_backend/pdf.rs
@@ -76,18 +76,18 @@ pub fn pdf_full(
     chart
         .draw_series(std::iter::once(PathElement::new(
             mean.to_line_vec(max_iters),
-            &colors.not_an_outlier,
+            colors.not_an_outlier,
         )))
         .unwrap()
         .label("Mean")
-        .legend(|(x, y)| PathElement::new(vec![(x, y), (x + 20, y)], &colors.not_an_outlier));
+        .legend(|(x, y)| PathElement::new(vec![(x, y), (x + 20, y)], colors.not_an_outlier));
 
     chart
         .draw_series(vec![
-            PathElement::new(low_mild.to_line_vec(max_iters), &colors.mild_outlier),
-            PathElement::new(high_mild.to_line_vec(max_iters), &colors.mild_outlier),
-            PathElement::new(low_severe.to_line_vec(max_iters), &colors.severe_outlier),
-            PathElement::new(high_severe.to_line_vec(max_iters), &colors.severe_outlier),
+            PathElement::new(low_mild.to_line_vec(max_iters), colors.mild_outlier),
+            PathElement::new(high_mild.to_line_vec(max_iters), colors.mild_outlier),
+            PathElement::new(low_severe.to_line_vec(max_iters), colors.severe_outlier),
+            PathElement::new(high_severe.to_line_vec(max_iters), colors.severe_outlier),
         ])
         .unwrap();
 
@@ -241,7 +241,7 @@ pub fn pdf_comparison(
         )))
         .unwrap()
         .label("Base Mean")
-        .legend(|(x, y)| PathElement::new(vec![(x, y), (x + 20, y)], &colors.previous_sample));
+        .legend(|(x, y)| PathElement::new(vec![(x, y), (x + 20, y)], colors.previous_sample));
 
     chart
         .draw_series(std::iter::once(PathElement::new(
@@ -250,7 +250,7 @@ pub fn pdf_comparison(
         )))
         .unwrap()
         .label("New Mean")
-        .legend(|(x, y)| PathElement::new(vec![(x, y), (x + 20, y)], &colors.current_sample));
+        .legend(|(x, y)| PathElement::new(vec![(x, y), (x + 20, y)], colors.current_sample));
 
     if !is_thumbnail {
         chart.configure_series_labels().draw().unwrap();

--- a/src/plot/plotters_backend/regression.rs
+++ b/src/plot/plotters_backend/regression.rs
@@ -41,7 +41,7 @@ pub fn regression(
         .x_desc(x_label)
         .y_desc(format!("Total sample time ({})", unit))
         .x_label_formatter(&|x| pretty_print_float(x * x_scale, true))
-        .light_line_style(&TRANSPARENT)
+        .light_line_style(TRANSPARENT)
         .draw()
         .unwrap();
 
@@ -57,7 +57,7 @@ pub fn regression(
     chart
         .draw_series(std::iter::once(PathElement::new(
             regression.to_line_vec(),
-            &colors.current_sample,
+            colors.current_sample,
         )))
         .unwrap()
         .label("Linear regression")
@@ -130,13 +130,13 @@ pub fn regression_comparison(
         .x_desc(x_label)
         .y_desc(format!("Total sample time ({})", unit))
         .x_label_formatter(&|x| pretty_print_float(x * x_scale, true))
-        .light_line_style(&TRANSPARENT)
+        .light_line_style(TRANSPARENT)
         .draw()
         .unwrap();
 
     chart
         .draw_series(vec![
-            PathElement::new(base_regression.to_line_vec(), &colors.previous_sample).into_dyn(),
+            PathElement::new(base_regression.to_line_vec(), colors.previous_sample).into_dyn(),
             Polygon::new(
                 vec![
                     (
@@ -167,7 +167,7 @@ pub fn regression_comparison(
 
     chart
         .draw_series(vec![
-            PathElement::new(current_regression.to_line_vec(), &colors.current_sample).into_dyn(),
+            PathElement::new(current_regression.to_line_vec(), colors.current_sample).into_dyn(),
             Polygon::new(
                 vec![
                     (

--- a/src/plot/plotters_backend/summary.rs
+++ b/src/plot/plotters_backend/summary.rs
@@ -87,7 +87,7 @@ fn draw_line_comparison_figure<XR: AsRangedCoord<Value = f64>, YR: AsRangedCoord
             )
             .unwrap();
         if let Some(name) = name {
-            let name: &str = *name;
+            let name: &str = name;
             series.label(name).legend(move |(x, y)| {
                 Rectangle::new(
                     [(x, y - 5), (x + 20, y + 5)],
@@ -168,7 +168,7 @@ fn draw_violin_figure<XR: AsRangedCoord<Value = f64>, YR: AsRangedCoord<Value = 
             .draw_series(AreaSeries::new(
                 curve.to_points().map(|(x, y)| (x, base + y / 2.0)),
                 base,
-                &colors.current_sample,
+                colors.current_sample,
             ))
             .unwrap();
 
@@ -176,7 +176,7 @@ fn draw_violin_figure<XR: AsRangedCoord<Value = f64>, YR: AsRangedCoord<Value = 
             .draw_series(AreaSeries::new(
                 curve.to_points().map(|(x, y)| (x, base - y / 2.0)),
                 base,
-                &colors.current_sample,
+                colors.current_sample,
             ))
             .unwrap();
     }

--- a/src/plot/plotters_backend/t_test.rs
+++ b/src/plot/plotters_backend/t_test.rs
@@ -42,7 +42,7 @@ pub fn t_test(
         .draw_series(AreaSeries::new(
             t_distribution.to_points(),
             0.0,
-            &colors.current_sample.mix(0.25),
+            colors.current_sample.mix(0.25),
         ))
         .unwrap()
         .label("t distribution")
@@ -60,7 +60,7 @@ pub fn t_test(
         )))
         .unwrap()
         .label("t statistic")
-        .legend(|(x, y)| PathElement::new(vec![(x, y), (x + 20, y)], &colors.current_sample));
+        .legend(|(x, y)| PathElement::new(vec![(x, y), (x + 20, y)], colors.current_sample));
 
     chart.configure_series_labels().draw().unwrap();
 }


### PR DESCRIPTION
This fixes a number of redundant borrows and dereferences.

The repository currently seems to have a mix of LF and CRLF line separators. Perhaps enforcing a single style is in order. I believe that I haven't changed the separator style in the files I touched in this commit.