### PR TITLE
Handle Throughput::BytesDecimal

### DIFF
--- a/src/connection.rs
+++ b/src/connection.rs
@@ -245,6 +245,7 @@ pub struct PlotConfiguration {
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
 pub enum Throughput {
     Bytes(u64),
+    BytesDecimal(u64),
     Elements(u64),
 }
 

--- a/src/message_formats/json.rs
+++ b/src/message_formats/json.rs
@@ -23,7 +23,7 @@ struct Throughput {
 impl From<&ThroughputEnum> for Throughput {
     fn from(other: &ThroughputEnum) -> Self {
         match other {
-            ThroughputEnum::Bytes(bytes) => Throughput {
+            ThroughputEnum::Bytes(bytes) | ThroughputEnum::BytesDecimal(bytes) => Throughput {
                 per_iteration: *bytes,
                 unit: "bytes".to_owned(),
             },

--- a/src/report.rs
+++ b/src/report.rs
@@ -154,7 +154,9 @@ impl BenchmarkId {
 
     pub fn as_number(&self) -> Option<f64> {
         match self.throughput {
-            Some(Throughput::Bytes(n)) | Some(Throughput::Elements(n)) => Some(n as f64),
+            Some(Throughput::Bytes(n))
+            | Some(Throughput::BytesDecimal(n))
+            | Some(Throughput::Elements(n)) => Some(n as f64),
             None => self
                 .value_str
                 .as_ref()
@@ -164,7 +166,7 @@ impl BenchmarkId {
 
     pub fn value_type(&self) -> Option<ValueType> {
         match self.throughput {
-            Some(Throughput::Bytes(_)) => Some(ValueType::Bytes),
+            Some(Throughput::Bytes(_)) | Some(Throughput::BytesDecimal(_)) => Some(ValueType::Bytes),
             Some(Throughput::Elements(_)) => Some(ValueType::Elements),
             None => self
                 .value_str


### PR DESCRIPTION
Fixes the panic when encountering the relatively new throughput variant:

```
thread 'main' panicked at ***/criterion-0.5.1/src/benchmark_group.rsError: :316:30:
called `Result::unwrap()` on an `Err` value: Io(Os { code: 32, kind: BrokenPipe, message: "Broken pipe" })
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace

Caused by:
    0: Failed to parse message from Criterion.rs benchmark
    1: unknown variant `BytesDecimal`, expected `Bytes` or `Elements`
```